### PR TITLE
fix: remove engine requirements in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,11 +49,6 @@
       "cspell"
     ]
   },
-  "engines": {
-    "node": ">=0.12",
-    "npm": "please-use-yarn",
-    "yarn": ">= 1.19.1"
-  },
   "devDependencies": {
     "@commitlint/cli": "^16.0.2",
     "@commitlint/config-conventional": "^16.0.0",


### PR DESCRIPTION
This PR removes engine requirements in package.json to make it easier to use in CI environments.