### PR TITLE
feat: expose cpu info

### DIFF
--- a/src/web-capabilities.spec.ts
+++ b/src/web-capabilities.spec.ts
@@ -52,4 +52,10 @@ describe('WebCapabilities', () => {
     expect(WebCapabilities.isCapableOfReceiving1080pVideo()).toBe(CapabilityState.CAPABLE);
     expect(WebCapabilities.isCapableOfSending1080pVideo()).toBe(CapabilityState.CAPABLE);
   });
+  it('should return the number of cores', () => {
+    expect.hasAssertions();
+
+    mockCpuInfo({ numLogicalCores: 8 });
+    expect(WebCapabilities.getCpuInfo().numLogicalCores).toBe(8);
+  });
 });

--- a/src/web-capabilities.ts
+++ b/src/web-capabilities.ts
@@ -1,4 +1,4 @@
-import { getCpuInfo } from './cpu-info';
+import { CpuInfo, getCpuInfo } from './cpu-info';
 
 /**
  * Used by the {@link WebCapabilities} class to mark features as "not capable", "capable", or
@@ -76,5 +76,14 @@ export class WebCapabilities {
       return CapabilityState.NOT_CAPABLE;
     }
     return CapabilityState.CAPABLE;
+  }
+
+  /**
+   * Retrieves the current CPU information of the system.
+   *
+   * @returns An object containing details about the CPU.
+   */
+  static getCpuInfo(): CpuInfo {
+    return WebCapabilities.cpuInfo;
   }
 }


### PR DESCRIPTION
## Description

This PR introduces a new feature that allows the `CpuInfo` class to expose the number of CPU cores available on a system. 
## JIRA Ticket

[WEBEX-379500](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-379500)

## Changes
- Exposed the `getCpuInfo()`
- Added unit tests to verify the correctness of the core count retrieval under various scenarios.