### PR TITLE
feat: get screen and window info

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './browser-info';
 export * from './web-capabilities';
 export * from './cpu-info';
+export * from './window-info';

--- a/src/window-info.spec.ts
+++ b/src/window-info.spec.ts
@@ -1,0 +1,48 @@
+import { windowInfo } from './window-info';
+
+describe('windowInfo', () => {
+  it('returns the correct screen width and height when accessed', () => {
+    expect.hasAssertions();
+
+    jest.spyOn(window.screen, 'width', 'get').mockReturnValue(1280);
+    jest.spyOn(window.screen, 'height', 'get').mockReturnValue(720);
+
+    expect(windowInfo.getScreenWidth()).toBe(1280);
+    expect(windowInfo.getScreenHeight()).toBe(720);
+  });
+  it('returns undefined for screen width and height when the properties are not defined', () => {
+    expect.hasAssertions();
+
+    jest.spyOn(window.screen, 'height', 'get').mockImplementation();
+    jest.spyOn(window.screen, 'width', 'get').mockImplementation();
+
+    expect(windowInfo.getScreenWidth()).toBeUndefined();
+    expect(windowInfo.getScreenHeight()).toBeUndefined();
+  });
+  it('returns the correct window width and height when accessed', () => {
+    expect.hasAssertions();
+
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1080,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      value: 480,
+    });
+
+    expect(windowInfo.getWindowWidth()).toBe(1080);
+    expect(windowInfo.getWindowHeight()).toBe(480);
+  });
+  it('returns undefined for window width and height when the properties are not defined', () => {
+    expect.hasAssertions();
+
+    Object.defineProperty(window, 'innerWidth', {
+      value: undefined,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      value: undefined,
+    });
+
+    expect(windowInfo.getWindowWidth()).toBeUndefined();
+    expect(windowInfo.getWindowHeight()).toBeUndefined();
+  });
+});

--- a/src/window-info.ts
+++ b/src/window-info.ts
@@ -1,0 +1,40 @@
+/**
+ * Provides information about the screen dimensions.
+ */
+export class windowInfo {
+  /**
+   * Retrieves the width of the screen.
+   *
+   * @returns The width of the screen in pixels, or undefined if not available.
+   */
+  static getScreenWidth(): number | undefined {
+    return window.screen.width;
+  }
+
+  /**
+   * Retrieves the height of the screen.
+   *
+   * @returns The height of the screen in pixels, or undefined if not available.
+   */
+  static getScreenHeight(): number | undefined {
+    return window.screen.height;
+  }
+
+  /**
+   * Retrieves the width of the browser window's content area.
+   *
+   * @returns The width of the content area in pixels, or undefined if not available.
+   */
+  static getWindowWidth(): number | undefined {
+    return window.innerWidth;
+  }
+
+  /**
+   * Retrieves the height of the browser window's content area.
+   *
+   * @returns The height of the content area in pixels, or undefined if not available.
+   */
+  static getWindowHeight(): number | undefined {
+    return window.innerHeight;
+  }
+}


### PR DESCRIPTION
As part of [WEBEX-379503](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-379503)

Add screen and window size reporting for MQRs

Description:
Used for MQRs report_intervalMetadata_screenResolution and report_intervalMetadata_appWindow(Height/Width/Size).

Screen size can be retrieved from the Screen API: https://developer.mozilla.org/en-US/docs/Web/API/Screen.
Window size can be retrieved from the Window API: https://developer.mozilla.org/en-US/docs/Web/API/Window.
